### PR TITLE
Fix for game slowness after many battles, and "instant death" if new battle starts within 5 seconds of previous one

### DIFF
--- a/base.js
+++ b/base.js
@@ -622,8 +622,9 @@ $(document).ready(function() {
 			closemessage();
 			powerhp();
 			battle=makebattle(Math.round(Math.random()*100),"Monster",150,150,"Spatula??",15,"A monster",3,power,hp,hp,currentsword,false,"vs-monster");
-			html="<div class=\"alert alert-battle-monster\"><b>Monster!</b><br>There is a dangerous monster in the enchanting shop!<br><br>"+battle+"</div>";
+			html="<div class=\"alert alert-battle-monster\"><b>Monster!</b><br>There is a dangerous monster in the enchanting shop!<br><br>"+battle.html+"</div>";
 			$("#otheralerts").append(html);
+			battle.init();
 			closemessage();
 			$(".alert-battle-monster").fadeIn("fast");
 		}
@@ -644,8 +645,9 @@ $(document).ready(function() {
 			closemessage();
 			powerhp();
 			battle=makebattle(Math.round(Math.random()*100),"Ghost",400,400,"Invisible hands",27,"This ghost is gurading the chest",4,power,hp,hp,currentsword,false,"vs-ghost");
-			html="<div class=\"alert alert-battle-ghost\"><b>Ghost</b><br>The chest is guarded by a ghost<br><br>"+battle+"</div>";
+			html="<div class=\"alert alert-battle-ghost\"><b>Ghost</b><br>The chest is guarded by a ghost<br><br>"+battle.html+"</div>";
 			$("#otheralerts").append(html);
+			battle.init();
 			closemessage();
 			$(".alert-battle-ghost").fadeIn("fast");
 		}
@@ -802,8 +804,9 @@ chestascii='\n\
 		closemessage();
 		powerhp();
 		battle=makebattle(Math.round(Math.random()*100),"The Fox",2000,2000,"Unknown",1,"A fox!",10,power,hp,hp,currentsword,false,"vs-fox");
-		html="<div class=\"alert alert-battle-fox\"><b>The Fox</b><br>You choose to kill the fox<br><br>"+battle+"<br><br><input type=\"button\" value=\"Or stop attacking the innocent fox\" onclick=\"myhealthpoint(true,0); closemessage();\"></div>";
+		html="<div class=\"alert alert-battle-fox\"><b>The Fox</b><br>You choose to kill the fox<br><br>"+battle.html+"<br><br><input type=\"button\" value=\"Or stop attacking the innocent fox\" onclick=\"myhealthpoint(true,0); closemessage();\"></div>";
 		$("#otheralerts").append(html);
+		battle.init();
 		closemessage();
 		$(".alert-battle-fox").fadeIn("fast");
 	});
@@ -921,8 +924,9 @@ function testskill() {
 		powerhp();
 		hpdivide10=Math.ceil(hp/10);
 		battle=makebattle(Math.round(Math.random()*100),"Training Robot",hp+hpdivide10,hp+hpdivide10,"Short ranged laser!",power+Math.ceil(power/10),"A training robot",2,power,hp,hp,currentsword,false,"training");
-		html="<div class=\"alert alert-training\"><b>Test my skill!</b><br>Let's see how strong you are<br><br>"+battle+"</div>";
+		html="<div class=\"alert alert-training\"><b>Test my skill!</b><br>Let's see how strong you are<br><br>"+battle.html+"</div>";
 		$("#otheralerts").append(html);
+		battle.init();
 		closemessage();
 		$(".alert-training").fadeIn("fast");
 	}
@@ -958,8 +962,9 @@ function dighole() {
 	else {
 		powerhp();
 		battle=makebattle(Math.round(Math.random()*100),"Thief",100,100,"Handmade Sword",3,"A thief, nothing else",0,power,hp,hp,currentsword,false,"vs-thief");
-		html="<div class=\"alert alert-battle1\"><b>Attacked!</b><br>While you are digging the hole, suddenly someone runs towards you and tried to attack you<br><br>"+battle+"</div>";
+		html="<div class=\"alert alert-battle1\"><b>Attacked!</b><br>While you are digging the hole, suddenly someone runs towards you and tried to attack you<br><br>"+battle.html+"</div>";
 		$("#otheralerts").append(html);
+		battle.init();
 		closemessage();
 		$(".alert-battle1").fadeIn("fast");
 	}
@@ -967,8 +972,9 @@ function dighole() {
 function continuedigging() {
 	powerhp();
 	battle=makebattle(Math.round(Math.random()*100),"Worms",80,80,"Their body",15,"Worms!",1,power,hp,hp,currentsword,false,"vs-worms");
-	html="<div class=\"alert alert-battle2\"><b>Worms! :o</b><br>There are worms under the ground!<br>They seemed to be mad because you destroyed their home<br><br>"+battle+"</div>";
+	html="<div class=\"alert alert-battle2\"><b>Worms! :o</b><br>There are worms under the ground!<br>They seemed to be mad because you destroyed their home<br><br>"+battle.html+"</div>";
 	$("#otheralerts").append(html);
+	battle.init();
 	closemessage();
 	$(".alert-battle2").fadeIn("fast");
 }
@@ -1058,28 +1064,31 @@ function entercastle() {
 	closemessage();
 	powerhp();
 	battle=makebattle(Math.round(Math.random()*100),"Castle Guard",200,200,"Butter Sword!",30,"Guards the castle.",0,power,hp,hp,currentsword,false,"vs-castle-guard");
-	html="<div class=\"alert alert-castle\"><b>Castle</b><br>You are entering the castle...<br><br><div class=\"castle-steps\"><span class=\"castle-entrance\">Castle Entrance</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-hall\">Castle Hall</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-room\">King's Room</span></div><br><br>"+battle+"</div>";
+	html="<div class=\"alert alert-castle\"><b>Castle</b><br>You are entering the castle...<br><br><div class=\"castle-steps\"><span class=\"castle-entrance\">Castle Entrance</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-hall\">Castle Hall</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-room\">King's Room</span></div><br><br>"+battle.html+"</div>";
 	$("#otheralerts").append(html);
 	$(".castle-hall").addClass("grey");
 	$(".castle-room").addClass("grey");
+	battle.init();
 	$(".alert-castle").fadeIn("fast");
 }
 function castlegotohall(myfinalhp) {
 	powerhp();
 	battle=makebattle(Math.round(Math.random()*100),"Castle Staff",300,300,"Sword-like-knife",20,"The staff makes the castle look good.",0,power,myfinalhp,hp,currentsword,false,"vs-castle-staff");
-	html="<div class=\"alert alert-castle-hall\"><b>Castle</b><br>You are inside the castle...<br><br><div class=\"castle-steps\"><span class=\"castle-entrance\">Castle Entrance</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-hall\">Castle Hall</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-room\">King's Room</span></div><br><br>"+battle+"</div>";
+	html="<div class=\"alert alert-castle-hall\"><b>Castle</b><br>You are inside the castle...<br><br><div class=\"castle-steps\"><span class=\"castle-entrance\">Castle Entrance</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-hall\">Castle Hall</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-room\">King's Room</span></div><br><br>"+battle.html+"</div>";
 	$("#otheralerts").append(html);
 	$(".castle-entrance").addClass("grey");
 	$(".castle-room").addClass("grey");
+	battle.init();
 	$(".alert-castle-hall").fadeIn("fast");
 }
 function castlegotoking(myfinalhp) {
 	powerhp();
 	battle=makebattle(Math.round(Math.random()*100),"Zombie King",750,750,"Diamond Sword",50,"I AM THE BOSS!!",0,power,myfinalhp,hp,currentsword,false,"vs-castle-boss");
-	html="<div class=\"alert alert-castle-king\"><b>Castle</b><br>You are in front of the king! :o<br><br><div class=\"castle-steps\"><span class=\"castle-entrance\">Castle Entrance</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-hall\">Castle Hall</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-room\">King's Room</span></div><br><br>"+battle+"</div>";
+	html="<div class=\"alert alert-castle-king\"><b>Castle</b><br>You are in front of the king! :o<br><br><div class=\"castle-steps\"><span class=\"castle-entrance\">Castle Entrance</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-hall\">Castle Hall</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"castle-room\">King's Room</span></div><br><br>"+battle.html+"</div>";
 	$("#otheralerts").append(html);
 	$(".castle-entrance").addClass("grey");
 	$(".castle-hall").addClass("grey");
+	battle.init();
 	$(".alert-castle-king").fadeIn("fast");
 }
 function buyairplane() {
@@ -1155,7 +1164,8 @@ function enterportal(step,thehp2) {
 			else {
 				battle=makebattle(Math.round(Math.random()*100),"Weakened Ghost",200,200,"Invisible hands",17,"A weakened ghost.",4,power,hp,maxhp,currentsword,false,"in-the-nether-"+step);
 			}
-			$("#nether-battle-area").html(battle);
+			$("#nether-battle-area").html(battle.html);
+			battle.init();
 		}
 		else {
 			step++;
@@ -1395,8 +1405,9 @@ function vsinvisiblebot() {
 	closemessage();
 	powerhp();
 	battle=makebattle(Math.round(Math.random()*100),"Invisible Bot",300,300,"Invisible Sword",30,"An invisible bot",9,power,hp,hp,currentsword,false,"vs-invisible-bot");
-	html="<div class=\"alert alert-battle-invisible-bot\"><b>Invisible Bot</b><br>Here is the invisible bot, good luck!<br><br>"+battle+"</div>";
+	html="<div class=\"alert alert-battle-invisible-bot\"><b>Invisible Bot</b><br>Here is the invisible bot, good luck!<br><br>"+battle.html+"</div>";
 	$("#otheralerts").append(html);
+	battle.init();
 	closemessage();
 	$(".alert-battle-invisible-bot").fadeIn("fast");
 }
@@ -1641,8 +1652,9 @@ PS: He heals 3 HP each time he attacks you and he also absorb some damage from y
 		closemessage();
 		powerhp();
 		battle=makebattle(Math.round(Math.random()*100),"Mr. Professor",1000,1000,"Super powerful sword",50,"He brought you to this weird world!",0,power,hp,hp,currentsword,false,"vs-boss");
-		html="<div class=\"alert alert-boss-fight\"><b>Fight! Fight! Fight!</b><br>This dude has brought you to this weird world without permission, you have been searching for him for a long time, and now you found him!<br><br>"+battle+"</div>";
+		html="<div class=\"alert alert-boss-fight\"><b>Fight! Fight! Fight!</b><br>This dude has brought you to this weird world without permission, you have been searching for him for a long time, and now you found him!<br><br>"+battle.html+"</div>";
 		$("#otheralerts").append(html);
+		battle.init();
 		closemessage();
 		$(".alert-boss-fight").fadeIn("fast");
 	}
@@ -2135,9 +2147,6 @@ output="<table id=\"battle-"+id+"\">"+output2+"</table><br><div class=\"buttons-
 		enemyhealthpoint(true,hp);
 		enemyhealthpoint2(true,hp);
 		setTimeout(function(){enemyattack(id,damage);},2000+Math.random()*1000);
-		healthpotion(id);
-		skillbutton(id);
-		potionsbutton(id);
 		theparam(true,param);
 		isinvuln(true,false);
 		battlestop(true,false);
@@ -2163,11 +2172,20 @@ output="<table id=\"battle-"+id+"\">"+output2+"</table><br><div class=\"buttons-
 		skilldelay(id,0);
 	}
 	
+	var init_func = function() { 
+						checkhealthbutton(id);
+						checkskillbutton(id);
+						checkpotionsbutton(id);
+				};
+	
 	if(!loop) {
-		return output;
+		return { html: output,
+			     init: init_func
+				};
 	}
 	else {
 		$("#battle-"+id).html(output2);
+		init_func();
 	}
 }
 function enemyattack(id,damage) {
@@ -2303,25 +2321,23 @@ function attackdelay(id,sec) {
 		$(".button-attack-"+id).attr("value","Attack!");
 	}
 }
-function healthpotion(id) {
+function checkhealthbutton(id) {
 	if(items[7].owned!=0) {
 		$(".button-health-"+id).show();
 	}
 	else {
 		$(".button-health-"+id).hide();
 	}
-	setTimeout(function(){healthpotion(id);},100);
 }
-function skillbutton(id) {
+function checkskillbutton(id) {
 	if(skill!="none") {
 		$(".button-skill-"+id).show();
 	}
 	else {
 		$(".button-skill-"+id).hide();
 	}
-	setTimeout(function(){skillbutton(id);},100);
 }
-function potionsbutton(id) {
+function checkpotionsbutton(id) {
 	for(i=11;i<=18;i++) {
 		thepotionname=items[i];
 		if(thepotionname.owned>0) {
@@ -2331,12 +2347,12 @@ function potionsbutton(id) {
 			$(".button-potion-"+i+"-"+id).hide();
 		}
 	}
-	setTimeout(function(){potionsbutton(id);},100);
 }
 function drinkhealthpotion(id) {
 	if(items[7].owned!=0) {
 		if(enchant_countdown==1) { mindelay=6; } else { mindelay=7; }
 		items[7].owned-=1;
+		checkhealthbutton(id);
 		checkthings();
 		myhp=myhealthpoint(false,0);
 		myhp+=50;
@@ -2385,6 +2401,7 @@ function usetheskill(id) {
 function usepotion(pid,id) {
 	if(items[pid].owned>=1) {
 		items[pid].owned--;
+		checkpotionsbutton(id);
 		thepotionname=items[pid].name.replace(" potion","");
 		$(".button-potion-"+pid+"-"+id).val("["+items[pid].owned+"] "+thepotionname);
 		if(enchant_countdown==1) { mindelay=6; } else { mindelay=7; }
@@ -2890,8 +2907,9 @@ function battlevsrats() {
 		powerhp();
 		hpdivide=Math.ceil(hp/4.5);
 		battle=makebattle(Math.round(Math.random()*100),"A Rat",hp-hpdivide,hp-hpdivide,"Their body",power-Math.ceil(power/2.5),"An annoying rat",11,power,hp,hp,currentsword,false,"vs-rat");
-		html="<div class=\"alert alert-battle-rats\"><b>Rat!</b><br>Kill it!!<br><br>"+battle+"</div>";
+		html="<div class=\"alert alert-battle-rats\"><b>Rat!</b><br>Kill it!!<br><br>"+battle.html+"</div>";
 		$("#otheralerts").append(html);
+		battle.init();
 		closemessage();
 		$(".alert-battle-rats").fadeIn("fast");
 	}

--- a/base.js
+++ b/base.js
@@ -2227,6 +2227,10 @@ function enemyattack(id,damage) {
 					if(myhealthpoint(false,0)<=0) {
 						myhealthpoint(true,0)
 						myhp=myhealthpoint(false,0);
+						if (typeof asdasdf !== 'undefined') {
+							clearTimeout(asdasdf);
+							asdasdf = undefined;
+						}
 						enemyattack(id,damage,myhp);
 						if(!lagipusing) {
 							$(".enemy-"+id).animate({"margin-left":0+"px"},200);


### PR DESCRIPTION
While waiting to build up my gold and iron bar supplies, I decided to tackle two problems I'd observed with the game:

First, the game seemed to get slower and slower as time went on.  I could save my game, then reload the page, and the game would suddenly go much faster!

Second was the acknowledged issue that if, after winning or losing a battle, you started a new one within about 5 seconds, you would immediately die.

The first problem was caused by the timers that show/hide the various battle buttons (skill, health, other potions).  I made modifications so that these buttons are not controlled by any timers at all.

The second problem was due to the fact that when the battle ended, the "enemyattack" timers were not cancelled.  I resolved this problem by making sure that the timer is aborted when the battle is won or lost.
