### PR TITLE
Restore favicon as inline data URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 	<script type="text/javascript" src="base.js"></script>
 	
 	<link rel="stylesheet" type="text/css" href="style.css" media="all" />
-	<link rel="shortcut icon" href="http://s9.postimg.org/8lwm9t39n/favicon2.png" />
+	<link rel="shortcut icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAABBVBMVEUAAAAAAAAfGgADAwAAAAABAQAEAwDiugAAAAAAAAABAABuVRD3zgDtxQAUEQAAAAAAAAARBQD3zAAlHQEbFAIcFwDyxgQ4LQDBoAoPCwCzlAAYFwCWfAAeGxDRrAAvKhAFAwABAAB2XwAQDAASDwADAwAAAAAAAAACAAArCgAAAAAAAAD+/O/dtgD/0wL/6AEtJwH/2gD7zwArIwAfGQD//vf//fP/++D/9sb/9sP/9r+zjBWuiBWphBT/6Az/6AfxxgHXsQAmHwD/++f//a9sZ1D94Er/5UZjXkb/3h//3he4kxI3MhCTdwz84ARZSATx0gDnywDUtwC7oQCAbQBwXgAoIgDntoNKAAAALHRSTlMAEev4Bf30/jIMA/79/ftJGRf+/Pn49/b08/Hw7Orq6efe3Nx2bWk4LCsjFqeF9X4AAAC4SURBVBjTdY7FFoJQFEXBJ6DY3d2KtEWD3e3/f4oPXSyZuGd7D+49yF/a+ZZbvbEaVXGHZhHjwu7QmIjcqxfzOk6C7WFt4Ymc/+tdXOQ2EyFtPPBP8YMyu7NCdJCXU1HoaClLLynB4Pm9EkDhR4waj0Zjah43ZRVEEMSHEQQxhJisEsDtTdUrexdvQjB0VpN9GCKZxXQ6m0nS6nkEPhjqNMMwuq5pp0t4QMITwONQwOynJPqjA6e/AQOGFpd1yYw+AAAAAElFTkSuQmCC" />
 	
 	<!-- Thanks to /u/Shawnyall and /u/Guildenstern_artist for the favicon! -->
 	


### PR DESCRIPTION
Image was downloaded from a [Web Archive snapshot of the original URL][og image],
compressed using [TinyPNG](https://tinypng.com) to remove seemingly useless metadata,
and then encoded as base64.

If you'd prefer the favicon be re-added as a normal file just let me know and I'll make another PR

[OG image]: https://web.archive.org/web/20141123174526/s9.postimg.org/8lwm9t39n/favicon2.png